### PR TITLE
BIT-239 mongo migration

### DIFF
--- a/tools/Lykke.Service.BlockchainWallets.ObsoleteAzureToMongoMigrator/Program.cs
+++ b/tools/Lykke.Service.BlockchainWallets.ObsoleteAzureToMongoMigrator/Program.cs
@@ -141,8 +141,9 @@ namespace Lykke.Service.BlockchainWallets.ObsoleteAzureToMongoMigrator
                             var captured = Interlocked.Add(ref counter, queryResult.Wallets.Count());
                             log.Info($"Processed  {captured} of unknown");
                         }
-                        catch (Exception)
+                        catch (Exception e)
                         {
+                            log.Error(e);
                             disrupt.Cancel();
 
                             throw;


### PR DESCRIPTION
Fix case when all wallets in batch are not primary. "insPrimary" tasks fails - mongo adapter throws exceptions that insert should contain at least one elemtnt 